### PR TITLE
Reimplemented call of findFirstNode() to prevent a null node on connection to HUD

### DIFF
--- a/package/tecla/addon/TeclaApp.java
+++ b/package/tecla/addon/TeclaApp.java
@@ -173,6 +173,7 @@ public class TeclaApp extends Application {
 			TeclaApp.overlay.show();
 			a11yservice.sendGlobalHomeAction();
 		}
+		AutomaticScan.findFirstNode();
 	}
 
 	public void turnHUDoff() {
@@ -196,6 +197,7 @@ public class TeclaApp extends Application {
 			a11yservice.showFullscreenSwitch();
 			a11yservice.sendGlobalHomeAction();
 		}
+		AutomaticScan.findFirstNode();
 		TeclaApp.persistence.setFullscreenEnabled(true);
 	}
 	


### PR DESCRIPTION
Fixed #365
