### PR TITLE
Removed duplicate instances of TeclaVisualOverlay and SingleSwitchTouchInterface

### DIFF
--- a/package/tecla/addon/AutomaticScan.java
+++ b/package/tecla/addon/AutomaticScan.java
@@ -25,9 +25,9 @@ public class AutomaticScan {
 	
 	private static void tick() {
 		sHandler.removeMessages(TICK);
-		if(TeclaApp.overlay.isVisible()
-				&& !TeclaApp.overlay.isPreview()) {
-			TeclaApp.overlay.scanNextHUDButton();
+		if(TeclaAccessibilityService.getTeclaOverlay().isVisible()
+				&& !TeclaAccessibilityService.getTeclaOverlay().isPreview()) {
+			TeclaAccessibilityService.getTeclaOverlay().scanNextHUDButton();
 		} else if(TeclaApp.getInstance().isSupportedIMERunning()) {
 			IMEAdapter.scanNext();			
 		}

--- a/package/tecla/addon/IMEAdapter.java
+++ b/package/tecla/addon/IMEAdapter.java
@@ -403,8 +403,8 @@ public class IMEAdapter {
 										//TeclaApp.ime.requestHideSelf(0);
 										IMEStates.reset();
 										TeclaApp.ime.hideWindow();
-										TeclaApp.overlay.hidePreviewHUD();
-										TeclaApp.overlay.show();
+										TeclaAccessibilityService.getTeclaOverlay().hidePreviewHUD();
+										TeclaAccessibilityService.getTeclaOverlay().show();
 										TeclaApp.persistence.setIMEShowing(false);
 									} else {									
 										sState = SCAN_COLUMN;
@@ -481,7 +481,7 @@ public class IMEAdapter {
 			if(IMEStates.sCurrentRow == IMEStates.sRowCount ) {
 				WordPredictionAdapter.highlightNext();
 			} else if(IMEStates.sCurrentRow == IMEStates.sRowCount + 1) {
-				TeclaApp.overlay.hidePreviewHUD();
+				TeclaAccessibilityService.getTeclaOverlay().hidePreviewHUD();
 			} else highlightKeys(IMEStates.sKeyStartIndex, IMEStates.sKeyEndIndex, false);
 			++sCurrentRow;
 			sCurrentRow %= sRowCount + 2;
@@ -493,9 +493,9 @@ public class IMEAdapter {
 					WordPredictionAdapter.highlightNext();
 			}
 			if(IMEStates.sCurrentRow == IMEStates.sRowCount + 1) {
-				TeclaApp.overlay.showPreviewHUD();
+				TeclaAccessibilityService.getTeclaOverlay().showPreviewHUD();
 			} else {
-				TeclaApp.overlay.hidePreviewHUD();
+				TeclaAccessibilityService.getTeclaOverlay().hidePreviewHUD();
 				highlightKeys(IMEStates.sKeyStartIndex, IMEStates.sKeyEndIndex, true);
 				}
 		}
@@ -504,7 +504,7 @@ public class IMEAdapter {
 			if(IMEStates.sCurrentRow == IMEStates.sRowCount ) {
 				WordPredictionAdapter.highlightNext();
 			} else if(IMEStates.sCurrentRow == -1) {
-				TeclaApp.overlay.showPreviewHUD();
+				TeclaAccessibilityService.getTeclaOverlay().showPreviewHUD();
 			} else highlightKeys(IMEStates.sKeyStartIndex, IMEStates.sKeyEndIndex, false);
 			--sCurrentRow;
 			if (sCurrentRow==-2){
@@ -518,9 +518,9 @@ public class IMEAdapter {
 					WordPredictionAdapter.highlightNext();
 			}
 			if(IMEStates.sCurrentRow == -1) {
-				TeclaApp.overlay.showPreviewHUD();
+				TeclaAccessibilityService.getTeclaOverlay().showPreviewHUD();
 			} else {
-				TeclaApp.overlay.hidePreviewHUD();
+				TeclaAccessibilityService.getTeclaOverlay().hidePreviewHUD();
 				highlightKeys(IMEStates.sKeyStartIndex, IMEStates.sKeyEndIndex, true);
 				}
 		}

--- a/package/tecla/addon/TeclaAccessibilityService.java
+++ b/package/tecla/addon/TeclaAccessibilityService.java
@@ -50,7 +50,7 @@ public class TeclaAccessibilityService extends AccessibilityService {
 	private int mNodeIndex;
 
 	private static TeclaVisualOverlay mVisualOverlay;
-	private SingleSwitchTouchInterface mFullscreenSwitch;
+	private static SingleSwitchTouchInterface mFullscreenSwitch;
 
 	protected static ReentrantLock mActionLock;
 	
@@ -78,12 +78,10 @@ public class TeclaAccessibilityService extends AccessibilityService {
 
 		if(mVisualOverlay == null) {
 			mVisualOverlay = new TeclaVisualOverlay(this);
-			//TeclaApp.setVisualOverlay(mVisualOverlay);
 		}
 		
 		if (mFullscreenSwitch == null) {
-			mFullscreenSwitch = new SingleSwitchTouchInterface(this);	
-			TeclaApp.setFullscreenSwitch(mFullscreenSwitch);		
+			mFullscreenSwitch = new SingleSwitchTouchInterface(this);			
 		}
 
 		// Bind to SwitchEventProvider
@@ -103,6 +101,13 @@ public class TeclaAccessibilityService extends AccessibilityService {
 			mVisualOverlay = new TeclaVisualOverlay(sInstance);
 			return mVisualOverlay;
 		}else return mVisualOverlay;
+	}
+	
+	public static SingleSwitchTouchInterface getFullscreenSwitch (){
+		if (mFullscreenSwitch == null) {
+			mFullscreenSwitch = new SingleSwitchTouchInterface(sInstance);	
+			return mFullscreenSwitch;		
+		}else return mFullscreenSwitch;
 	}
 	
 	public void hideFullscreenSwitch() {
@@ -626,4 +631,10 @@ public class TeclaAccessibilityService extends AccessibilityService {
 
 		}
 	};
+	
+	public static void setFullscreenSwitchLongClick(boolean enabled) {
+		if(mFullscreenSwitch != null)
+			mFullscreenSwitch.setLongClick(enabled);
+	}
+
 }

--- a/package/tecla/addon/TeclaAccessibilityService.java
+++ b/package/tecla/addon/TeclaAccessibilityService.java
@@ -49,12 +49,13 @@ public class TeclaAccessibilityService extends AccessibilityService {
 	private ArrayList<AccessibilityNodeInfo> mActiveNodes;
 	private int mNodeIndex;
 
-	private TeclaVisualOverlay mVisualOverlay;
+	private static TeclaVisualOverlay mVisualOverlay;
 	private SingleSwitchTouchInterface mFullscreenSwitch;
 
 	protected static ReentrantLock mActionLock;
 	
 	private final static String MAP_VIEW = "android.view.View";
+	
 	// For later use for custom actions 
 	//private final static String WEB_VIEW = "Web View";
 
@@ -77,7 +78,7 @@ public class TeclaAccessibilityService extends AccessibilityService {
 
 		if(mVisualOverlay == null) {
 			mVisualOverlay = new TeclaVisualOverlay(this);
-			TeclaApp.setVisualOverlay(mVisualOverlay);
+			//TeclaApp.setVisualOverlay(mVisualOverlay);
 		}
 		
 		if (mFullscreenSwitch == null) {
@@ -95,6 +96,13 @@ public class TeclaAccessibilityService extends AccessibilityService {
 
 		sInstance = this;
 		TeclaApp.setA11yserviceInstance(this);
+	}
+	
+	public static TeclaVisualOverlay getTeclaOverlay (){
+		if(mVisualOverlay == null) {
+			mVisualOverlay = new TeclaVisualOverlay(sInstance);
+			return mVisualOverlay;
+		}else return mVisualOverlay;
 	}
 	
 	public void hideFullscreenSwitch() {
@@ -348,7 +356,7 @@ public class TeclaAccessibilityService extends AccessibilityService {
 		
 		sInstance.mSelectedNode.performAction(AccessibilityNodeInfo.ACTION_CLICK);
 		if(sInstance.mVisualOverlay.isVisible()) 
-			TeclaApp.overlay.clearHighlight();
+			getTeclaOverlay().clearHighlight();
 	}
 
 	//	public static void selectActiveNode(int index) {

--- a/package/tecla/addon/TeclaApp.java
+++ b/package/tecla/addon/TeclaApp.java
@@ -39,7 +39,6 @@ public class TeclaApp extends Application {
 	public static Persistence persistence;
 	public static TeclaIME ime;
 	public static TeclaAccessibilityService a11yservice;
-	public static TeclaVisualOverlay overlay;
 	public static SingleSwitchTouchInterface fullscreenswitch;
 	public static TeclaSettingsActivity settingsactivity;
 
@@ -134,10 +133,6 @@ public class TeclaApp extends Application {
 		ime = ime_instance;
 		getInstance().processFrameworkOptions();
 	}
-
-	public static void setVisualOverlay (TeclaVisualOverlay overlay_instance) {
-		overlay = overlay_instance;
-	}
 	
 	public static void setA11yserviceInstance (TeclaAccessibilityService a11yservice_instance) {
 		a11yservice = a11yservice_instance;
@@ -172,7 +167,7 @@ public class TeclaApp extends Application {
 		else
 			AutomaticScan.stopAutoScan();
 		if (a11yservice != null) {
-			TeclaApp.overlay.show();
+			TeclaAccessibilityService.getTeclaOverlay().show();
 			a11yservice.sendGlobalHomeAction();
 		}
 	}
@@ -181,7 +176,7 @@ public class TeclaApp extends Application {
 		TeclaApp.a11yservice.hideFullscreenSwitch();
 		//TeclaApp.persistence.setSelfScanningEnabled(false);
 		AutomaticScan.stopAutoScan();				
-		TeclaApp.overlay.hide();
+		TeclaAccessibilityService.getTeclaOverlay().hide();
 		/*
 		if(TeclaApp.settingsactivity != null) {
 			TeclaApp.settingsactivity.uncheckFullScreenMode();
@@ -194,7 +189,7 @@ public class TeclaApp extends Application {
 		if(!persistence.isInverseScanningEnabled())
 			AutomaticScan.startAutoScan();
 		if (a11yservice != null) {
-			TeclaApp.overlay.show();
+			TeclaAccessibilityService.getTeclaOverlay().show();
 			a11yservice.showFullscreenSwitch();
 			a11yservice.sendGlobalHomeAction();
 		}
@@ -205,7 +200,7 @@ public class TeclaApp extends Application {
 		TeclaApp.a11yservice.hideFullscreenSwitch();
 		TeclaApp.persistence.setSelfScanningEnabled(false);
 		AutomaticScan.stopAutoScan();				
-		TeclaApp.overlay.hide();
+		TeclaAccessibilityService.getTeclaOverlay().hide();
 		TeclaApp.persistence.setFullscreenEnabled(false);
 		if(TeclaApp.settingsactivity != null) {
 			TeclaApp.settingsactivity.uncheckFullScreenMode();

--- a/package/tecla/addon/TeclaApp.java
+++ b/package/tecla/addon/TeclaApp.java
@@ -39,7 +39,6 @@ public class TeclaApp extends Application {
 	public static Persistence persistence;
 	public static TeclaIME ime;
 	public static TeclaAccessibilityService a11yservice;
-	public static SingleSwitchTouchInterface fullscreenswitch;
 	public static TeclaSettingsActivity settingsactivity;
 
 	private PowerManager power_manager;
@@ -141,15 +140,6 @@ public class TeclaApp extends Application {
 
 	public static void setSettingsActivityInstance (TeclaSettingsActivity settingsactivity_instance) {
 		settingsactivity = settingsactivity_instance;
-	}
-
-	public static void setFullscreenSwitch (SingleSwitchTouchInterface fullscreenswitch_instance) {
-		fullscreenswitch = fullscreenswitch_instance;
-	}
-	
-	public static void setFullscreenSwitchLongClick(boolean enabled) {
-		if(fullscreenswitch != null)
-			fullscreenswitch.setLongClick(enabled);
 	}
 	
 	private void processFrameworkOptions() {

--- a/package/tecla/addon/TeclaIME.java
+++ b/package/tecla/addon/TeclaIME.java
@@ -72,12 +72,12 @@ public class TeclaIME extends InputMethodService {
 	@Override
 	public void onStartInputView(EditorInfo info, boolean restarting) {
 		if(TeclaApp.getInstance().isTeclaA11yServiceRunning()
-				&& TeclaApp.overlay.isVisible()) {
+				&& TeclaAccessibilityService.getTeclaOverlay().isVisible()) {
 			Message msg = new Message();
 			msg.what = MSG_IMESCAN_SETUP;
 			msg.arg1 = 0;
 			mHandler.sendMessageDelayed(msg, 250);				
-			TeclaApp.overlay.hide();
+			TeclaAccessibilityService.getTeclaOverlay().hide();
 		}
 		
 		super.onStartInputView(info, restarting);
@@ -90,8 +90,8 @@ public class TeclaIME extends InputMethodService {
 		TeclaApp.persistence.setIMEShowing(false);
 		if(TeclaApp.persistence.shouldShowHUD()){
 				//&& !TeclaApp.overlay.isVisible()) {
-			TeclaApp.overlay.showPreviewHUD();
-			TeclaApp.overlay.show();
+			TeclaAccessibilityService.getTeclaOverlay().showPreviewHUD();
+			TeclaAccessibilityService.getTeclaOverlay().show();
 		}
 			
 		super.onFinishInputView(finishingInput);

--- a/package/tecla/addon/TeclaPreferenceFragment.java
+++ b/package/tecla/addon/TeclaPreferenceFragment.java
@@ -99,14 +99,14 @@ public class TeclaPreferenceFragment extends PreferenceFragment
 			TeclaStatic.logD(CLASS_TAG, "Inverse scanning preference changed!");
 			if (newValue.toString().equals("true")) {
 				TeclaApp.persistence.setInverseScanningEnabled(true);
-				TeclaApp.setFullscreenSwitchLongClick(false);
+				TeclaAccessibilityService.setFullscreenSwitchLongClick(false);
 				if(TeclaApp.persistence.isFullscreenEnabled() 
 						&& TeclaApp.persistence.isSelfScanningEnabled()) {
 					AutomaticScan.stopAutoScan();
 				}
 			} else {
 				TeclaApp.persistence.setInverseScanningEnabled(false);
-				TeclaApp.setFullscreenSwitchLongClick(true);
+				TeclaAccessibilityService.setFullscreenSwitchLongClick(true);
 				if(TeclaApp.persistence.isFullscreenEnabled() 
 						&& TeclaApp.persistence.isSelfScanningEnabled()) {
 					AutomaticScan.startAutoScan();


### PR DESCRIPTION
Removed unnecessary instances of TeclaVisualOverlay and Single SwitchTouchInterface. Reconnected affected calls to call the TeclaAccessibility class, pulling the instances as a singleton.
